### PR TITLE
Upgrade search-service to 0.3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {
@@ -23,7 +23,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@internetarchive/local-cache": "^0.2.1",
-    "@internetarchive/search-service": "^0.3.4",
+    "@internetarchive/search-service": "^0.3.5",
     "lit": "^2.0.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -127,10 +127,10 @@
   resolved "https://registry.yarnpkg.com/@internetarchive/result-type/-/result-type-0.0.1.tgz#a1bda4428dc557cc644a67783f1b8d5944ae4d54"
   integrity sha512-sWahff5oP1xAK1CwAu1/5GTG2RXsdx/sQKn4SSOWH0r0vU2QoX9kAom/jSXeBsmgK0IjTc+9Ty9407SMORi+nQ==
 
-"@internetarchive/search-service@^0.3.4":
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-0.3.4.tgz#241f005ba067ef017efca1ffe9c0705e68ab7f2e"
-  integrity sha512-7kBNAphUe0hVMv/mcP9xxUPQg6MkU6oDj+1CcS/XgofxI5xR+qIF2EqQpseI1gTtAOtqQ3Gj094dtt51KP1fzg==
+"@internetarchive/search-service@^0.3.5":
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-0.3.5.tgz#8e2af1975d223afbfad43fbb4119428a0bcb0c08"
+  integrity sha512-+v9RGRDEqyLoxrtpA9ZwhIyH/pZzJf/PE40ItUNYQkR/g974ip9L6iyfiCqx5mhxdX6E1nFoCvaDWSjQqklfwA==
   dependencies:
     "@internetarchive/field-parsers" "^0.1.3"
     "@internetarchive/result-type" "^0.0.1"


### PR DESCRIPTION
Upgrading to the latest search-service version to prepare for FTS integration.

Bumps version to 0.1.5