### PR TITLE
Upgrade search service to 0.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {
@@ -23,7 +23,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@internetarchive/local-cache": "^0.2.1",
-    "@internetarchive/search-service": "^0.4.2-alpha.1",
+    "@internetarchive/search-service": "^0.4.2",
     "lit": "^2.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
IA search-service v0.4.2 introduces new PPS params `uid` and `client_url`. This upgrade ensures those are available.