### PR TITLE
WEBDEV-5842 Add method for adding known titles to the cache without a fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@internetarchive/local-cache": "^0.2.1",
-    "@internetarchive/search-service": "^0.4.6",
+    "@internetarchive/search-service": "^0.4.7-alpha.1",
     "lit": "^2.0.2"
   },
   "devDependencies": {

--- a/src/collection-name-cache.ts
+++ b/src/collection-name-cache.ts
@@ -23,6 +23,14 @@ export interface CollectionNameCacheInterface {
    * @param identifiers
    */
   preloadIdentifiers(identifiers: string[]): Promise<void>;
+
+  /**
+   * Adds a set of known identifier-title mappings to the cache,
+   * without sending a request for them.
+   *
+   * @param identifierTitleMap
+   */
+  addKnownTitles(identifierTitleMap: Record<string, string>): Promise<void>;
 }
 
 // this is the callback type received after the name is fetched
@@ -90,6 +98,22 @@ export class CollectionNameCache implements CollectionNameCacheInterface {
       this.pendingIdentifierQueue.add(identifier);
     }
     this.startPendingIdentifierTimer();
+  }
+
+  /** @inheritdoc */
+  async addKnownTitles(
+    identifierTitleMap: Record<string, string>
+  ): Promise<void> {
+    if (!this.cacheLoaded) await this.loadFromCache();
+    Object.entries(identifierTitleMap).forEach(([identifier, title]) => {
+      const lowercaseIdentifier = identifier.toLowerCase();
+      this.collectionNameCache[lowercaseIdentifier] = {
+        name: title,
+        lastAccess: Date.now(),
+      };
+    });
+
+    await this.persistCache();
   }
 
   private pendingIdentifierQueue: Set<string> = new Set<string>();

--- a/yarn.lock
+++ b/yarn.lock
@@ -132,10 +132,10 @@
   resolved "https://registry.npmjs.org/@internetarchive/result-type/-/result-type-0.0.1.tgz"
   integrity sha512-sWahff5oP1xAK1CwAu1/5GTG2RXsdx/sQKn4SSOWH0r0vU2QoX9kAom/jSXeBsmgK0IjTc+9Ty9407SMORi+nQ==
 
-"@internetarchive/search-service@^0.4.6":
-  version "0.4.6"
-  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-0.4.6.tgz#8c3f441a323a009123b93d0d1404ddb8d3904305"
-  integrity sha512-3BvPg5uHb7oVa92PHIkzsBNm3fbryGF0kDxtl4XH+6LqMM/cL5WfHY647tTT+0k98VUQhJMZTp16+T1zzXIZGw==
+"@internetarchive/search-service@^0.4.7-alpha.1":
+  version "0.4.7-alpha.1"
+  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-0.4.7-alpha.1.tgz#8027d74a9d3399d6be6edceeeb32b7129f74a674"
+  integrity sha512-Gcv0mQh1iuaEI4txeBJmJVgI7uyUZATblANQI7LLt0zB6wLb9MLQo6j6aC4ZJaL+R6RNs+vqLL8EpUDkaeMjxA==
   dependencies:
     "@internetarchive/field-parsers" "^0.1.3"
     "@internetarchive/result-type" "^0.0.1"


### PR DESCRIPTION
In cases where the collection titles for one or more identifiers are already known, it is valuable to be able to add these to the cache without triggering a fetch for them.

This is presently relevant to the search page, as backend responses may now include a map of collection identifiers to titles as part of the initial payload. This map is eventually intended to be included on all responses that contain collection identifiers in hits/aggregations, which will eliminate the need for this cache entirely. Until then, this PR ensures that titles can be cached both from known values or via identifier lookups.