### PR TITLE
Fix a race condition where known titles added could still get fetched

### DIFF
--- a/src/async-collection-name.ts
+++ b/src/async-collection-name.ts
@@ -1,6 +1,6 @@
 import { html, LitElement, PropertyValues } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
-import { CollectionNameCacheInterface } from './collection-name-cache';
+import type { CollectionNameCacheInterface } from './collection-name-cache.js';
 
 @customElement('async-collection-name')
 export class AsyncCollectionName extends LitElement {


### PR DESCRIPTION
If known titles are added at the same time as one of them being asynchronously read, that title could still end up being fetched during the limbo period between the cache load/persist. This fix ensures the methods which can trigger a fetch will await any pending known title additions to avoid that.