### PR TITLE
v0.2.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "AGPL-3.0-only",
   "author": "Internet Archive",
-  "version": "0.2.16",
+  "version": "0.2.18",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "type": "module",
@@ -24,7 +24,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@internetarchive/local-cache": "^0.2.1",
-    "@internetarchive/search-service": "^1.2.4",
+    "@internetarchive/search-service": "^1.3.0",
     "lit": "^2.0.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -132,10 +132,10 @@
   resolved "https://registry.npmjs.org/@internetarchive/result-type/-/result-type-0.0.1.tgz"
   integrity sha512-sWahff5oP1xAK1CwAu1/5GTG2RXsdx/sQKn4SSOWH0r0vU2QoX9kAom/jSXeBsmgK0IjTc+9Ty9407SMORi+nQ==
 
-"@internetarchive/search-service@^1.2.4":
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-1.2.4.tgz#1dccc2249936de8588a4f4e1c94ce21c3b0a64fe"
-  integrity sha512-GZF0HjFMaXjko38kgsmNYp6ndmcIfz1qtxNwiIGq2sHHb/Xi58vRFCAwCenoPtCGCO29D0lY7DNHuOEqcv3hLA==
+"@internetarchive/search-service@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@internetarchive/search-service/-/search-service-1.3.0.tgz#5d77623faee592d5e1ac9f573d02d52dd2dc54f9"
+  integrity sha512-RTSSmgG3S2RmSCmGarMD8h80PQw4at3yNUMAiyzhH56kLSBjSBEdM6ayDp1H7uUbTcLT35NCKGD4xPvqcZypcQ==
   dependencies:
     "@internetarchive/field-parsers" "^0.1.4"
     "@internetarchive/result-type" "^0.0.1"


### PR DESCRIPTION
Upgrades to `search-service@1.3.0` w/ profile page models, and bumps package version to 0.2.18.