### PR TITLE
WEBDEV-6594 Deprecate collection-name-cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Build Status](https://github.com/internetarchive/iaux-typescript-wc-template/actions/workflows/ci.yml/badge.svg)
 
-<h1>This package is deprecated.</h1>
-<h2>It is no longer recommended to fetch collection titles via sidecar requests or cache them locally in this way. Other iaux components now simply rely on collection titles being provided alongside the other content that requires them (e.g., search results).</h2>
+# This package is deprecated.
+### It is no longer recommended to fetch collection titles via sidecar requests or cache them locally in this way. Other iaux components now simply rely on collection titles being provided alongside the other content that requires them (e.g., search results).
 <hr>
 
 # Internet Archive Typescript WebComponent Template

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 ![Build Status](https://github.com/internetarchive/iaux-typescript-wc-template/actions/workflows/ci.yml/badge.svg)
 
+<h1>This package is deprecated.</h1>
+<h2>It is no longer recommended to fetch collection titles via sidecar requests or cache them locally in this way. Other iaux components now simply rely on collection titles being provided alongside the other content that requires them (e.g., search results).</h2>
+<hr>
+
 # Internet Archive Typescript WebComponent Template
 
 This is a base template for creating Typescript WebComponents. It is based off of the [Open WebComponents generator](https://open-wc.org/docs/development/generator/) with some IA-specific customizations and some development niceities.


### PR DESCRIPTION
Marks this package as deprecated.

The PPS now provides a `collection_titles` branch on any responses that include collection identifiers, containing all the necessary titles to use when rendering. It is undesired for our components to be making sidecar requests for this data outside of the usual PPS flow, or caching it locally for extended periods of time with no means of cache invalidation.